### PR TITLE
Escaped words containing "regex-like" characters to also match correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",
     "chai": "^4.2.0",
-    "eslint": "^7.24.0",
+    "eslint": "7.15.0",
     "husky": "^4.3.6",
     "lint-staged": "^10.5.3",
     "mocha": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "bad language",
     "dirty words"
   ],
-  "dependencies": {},
   "devDependencies": {
     "@types/chai": "^4.2.14",
     "@types/mocha": "^8.2.0",
@@ -47,7 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",
     "chai": "^4.2.0",
-    "eslint": "^7.15.0",
+    "eslint": "^7.24.0",
     "husky": "^4.3.6",
     "lint-staged": "^10.5.3",
     "mocha": "^8.2.1",

--- a/src/list.ts
+++ b/src/list.ts
@@ -15,7 +15,7 @@ export class List {
 
   loadFile(filename: string): void {
     const file = readFileSync(filename, "utf8");
-    this.words = file.split("\n").filter((x) => x);
+    this.words = file.split(/[\r\n]+/).filter((x) => x);
     this.onListChanged();
   }
 

--- a/src/profanity.spec.ts
+++ b/src/profanity.spec.ts
@@ -57,6 +57,18 @@ describe("Profanity", () => {
     it("should return true when profanity exists as part of a single word", () => {
       expect(customProfanity.exists("arsenic")).to.equal(true);
     });
+
+    it("Should return false when the last character is an 'A' with no profanity (A$$ edge case)", () => {
+      expect(customProfanity.exists("FUNTIMESA")).to.equal(false);
+    });
+
+    it("Should return true when the last character is an 'A' and there is profanity (A$$ edge case)", () => {
+      expect(customProfanity.exists("BUTTSA")).to.equal(true);
+    });
+
+    it("Should return true when some regex characters are present as profanity", () => {
+      expect(customProfanity.exists("lovea$$")).to.equal(true);
+    });
   });
 
   describe("censor", () => {

--- a/src/profanity.ts
+++ b/src/profanity.ts
@@ -3,6 +3,10 @@ import { resolve } from "path";
 import { ProfanityOptions } from "./profanity-options";
 import { List } from "./list";
 
+function escapeRegExp(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export class Profanity {
   options: ProfanityOptions;
   whitelist: List;
@@ -36,8 +40,11 @@ export class Profanity {
   }
 
   private buildRegex(): void {
-    const blacklistPattern = `${this.options.wholeWord ? "\\b" : ""}(${this.blacklist.words.join("|")})${this.options.wholeWord ? "\\b" : ""}`;
-    const whitelistPattern = this.whitelist.empty ? "" : `(?!${this.whitelist.words.join("|")})`;
+    const escapedBlacklistWords = this.blacklist.words.map(escapeRegExp);
+    const escapedWhitelistWords = this.whitelist.words.map(escapeRegExp);
+
+    const blacklistPattern = `${this.options.wholeWord ? "\\b" : ""}(${escapedBlacklistWords.join("|")})${this.options.wholeWord ? "\\b" : ""}`;
+    const whitelistPattern = this.whitelist.empty ? "" : `(?!${escapedWhitelistWords.join("|")})`;
     this.regex = new RegExp(whitelistPattern + blacklistPattern, "ig");
   }
 }

--- a/src/words.txt
+++ b/src/words.txt
@@ -18,6 +18,8 @@ assholes
 asswhole
 a_s_s
 a$$
+as$
+a$s
 b!tch
 b00bs
 b17ch


### PR DESCRIPTION
As per #18 , the word "a$$" was causing all words ending with "A" to be a false positive for profanity, because of the regex character "$" meaning "end-of-match".

These characters are now escaped in the regex like so: `a\$\$`, so it matches correctly.