### PR TITLE
Fix breaking change causing null and booleans to make a breaking error

### DIFF
--- a/src/profanity.ts
+++ b/src/profanity.ts
@@ -20,6 +20,7 @@ export class Profanity {
   }
 
   exists(text: string): boolean {
+    text = typeof text === 'string' ? text : '';
     this.regex.lastIndex = 0;
     const lowercaseText = text.toLowerCase();
 

--- a/src/profanity.ts
+++ b/src/profanity.ts
@@ -20,7 +20,9 @@ export class Profanity {
   }
 
   exists(text: string): boolean {
-    text = typeof text === 'string' ? text : '';
+    if (typeof text !== "string") {
+      return false;
+    }
     this.regex.lastIndex = 0;
     const lowercaseText = text.toLowerCase();
 
@@ -64,6 +66,9 @@ export class Profanity {
   }
 
   censor(text: string, censorType: CensorType = CensorType.Word): string {
+    if (typeof text !== "string") {
+      return text;
+    }
     const lowercaseText = text.toLowerCase();
 
     switch (censorType) {


### PR DESCRIPTION
A change in Release 2.4.0 has made null and boolean inputs to trigger an error. This was not the case before.

`const { profanity, CensorType } = require('@2toad/profanity');

console.log(profanity.exists('I like big butts and I cannot lie'));
console.log(profanity.exists('I like cheeseburgers'));
console.log(profanity.exists(null));
console.log(profanity.exists(true));
`

`node_modules\@2toad\profanity\dist\profanity.js:17
        const lowercaseText = text.toLowerCase();
                                   ^

TypeError: Cannot read properties of null (reading 'toLowerCase')
    at Profanity.exists (C:\Users\User\Documents\soundbites\src\soundbites\node_modules\@2toad\profanity\dist\profanity.js:17:36)
    at Object.<anonymous> (C:\Users\User\Documents\soundbites\src\soundbites\testing.js:5:23)
    at Module._compile (node:internal/modules/cjs/loader:1369:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
    at Module.load (node:internal/modules/cjs/loader:1206:32)
    at Module._load (node:internal/modules/cjs/loader:1022:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49`