### PR TITLE
Add 'hurensohn' to profane words list

### DIFF
--- a/src/data/profane-words.ts
+++ b/src/data/profane-words.ts
@@ -1153,6 +1153,7 @@ export const profaneWords: Map<string, string[]> = new Map([
       "wank",
       "wahnsinn",
       "hure",
+      "hurensohn",
       "willies",
       "willy",
     ],


### PR DESCRIPTION
Found a common german word that is missing.